### PR TITLE
fix missing self in Errors.py

### DIFF
--- a/src/SOAPpy/Errors.py
+++ b/src/SOAPpy/Errors.py
@@ -55,7 +55,7 @@ class Error(exceptions.Exception):
         return "<Error : %s>" % self.msg
     __repr__ = __str__
     def __call__(self):
-        return (msg,)
+        return (self.msg,)
 
 class RecursionError(Error):
     pass


### PR DESCRIPTION
Using Plone I got the Error:

```
...
  File "<DIR>/Zope2-2.13.22-py2.7.egg/Products/PageTemplates/Expressions.py", line 117, in render
    ob = ob()
  File "build/bdist.linux-x86_64/egg/SOAPpy/Errors.py", line 58, in __call__
    return (msg,)
NameError: global name 'msg' is not defined
```

But this seems to be a small typo!