### PR TITLE
Added missing return in dump_dispatch for void type objects

### DIFF
--- a/src/SOAPpy/SOAPBuilder.py
+++ b/src/SOAPpy/SOAPBuilder.py
@@ -629,6 +629,7 @@ class SOAPBuilder:
 
         if isinstance(obj, voidType):     # void
             self.out.append("<%s%s%s></%s>\n" % (tag, a, r, tag))
+            return
         else:
             id = self.checkref(obj, tag, ns_map)
             if id == None:


### PR DESCRIPTION
When dumping a void type object, it continues to the next type check and you'll get the following traceback:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/SOAPpy/Server.py", line 415, in do_POST
    config = self.server.config)
  File "/usr/lib/python2.7/dist-packages/SOAPpy/SOAPBuilder.py", line 709, in buildSOAP
    return t.build()
  File "/usr/lib/python2.7/dist-packages/SOAPpy/SOAPBuilder.py", line 152, in build
    self.dump(v, k, typed = typed, ns_map = ns_map)
  File "/usr/lib/python2.7/dist-packages/SOAPpy/SOAPBuilder.py", line 289, in dump
    self.dump_dispatch(obj, tag, typed, ns_map)
  File "/usr/lib/python2.7/dist-packages/SOAPpy/SOAPBuilder.py", line 682, in dump_dispatch
    (tag, t, id, a, r, obj._marshalData(), tag))
UnboundLocalError: local variable 'id' referenced before assignment
```

If the instance is of void type it should return and not continue.